### PR TITLE
add account button to right of logo on main menu

### DIFF
--- a/src/components/MainMenu/MainMenu.tsx
+++ b/src/components/MainMenu/MainMenu.tsx
@@ -94,6 +94,61 @@ const MainMenu: React.FC = () => {
                         ))
                       }
                     />
+                    <Online>
+                <Media
+                  query={{ maxWidth: smallScreen }}
+                  render={() => (
+                    <>
+                      {user ? (
+                        <MenuDropdown
+                          suffixClass={'__rightdown'}
+                          head={
+                            <li className="main-menu__icon main-menu__user--active">
+                              <ReactSVG path={userImg} />
+                            </li>
+                          }
+                          content={
+                            <ul className="main-menu__dropdown">
+                              <li data-testid="my_account__link">
+                                <Link to={appPaths.accountUrl}>My Account</Link>
+                              </li>
+                              <li data-testid="order_history__link">
+                                <Link to={appPaths.orderHistoryUrl}>
+                                  Order history
+                                </Link>
+                              </li>
+                              <li data-testid="address_book__link">
+                                <Link to={appPaths.addressBookUrl}>
+                                  Address book
+                                </Link>
+                              </li>
+                              <li
+                                onClick={handleSignOut}
+                                data-testid="logout-link"
+                              >
+                                Log Out
+                              </li>
+                            </ul>
+                          }
+                        />
+                      ) : (
+                        <li
+                          data-testid="login-btn"
+                          className="main-menu__icon"
+                          onClick={() =>
+                            overlayContext.show(
+                              OverlayType.login,
+                              OverlayTheme.left
+                            )
+                          }
+                        >
+                          <ReactSVG path={userImg} />
+                        </li>
+                      )}
+                    </>
+                  )}
+                />
+              </Online>
                   </ul>
                 );
               }}

--- a/src/components/MenuDropdown/index.tsx
+++ b/src/components/MenuDropdown/index.tsx
@@ -6,9 +6,13 @@ class MenuDropdown extends React.Component<
   {
     head: React.ReactElement<{}>;
     content: React.ReactElement<{}>;
+    suffixClass: string;
   },
   { active: boolean }
 > {
+  static defaultProps = {
+    suffixClass: "",
+  };
   constructor(props) {
     super(props);
     this.state = { active: false };
@@ -24,7 +28,7 @@ class MenuDropdown extends React.Component<
         {this.props.head}
 
         <div
-          className={`menu-dropdown__body${
+          className={`menu-dropdown__body${" menu-dropdown__body"+this.props.suffixClass}${
             this.state.active ? " menu-dropdown__body--visible" : ""
           }`}
         >

--- a/src/components/MenuDropdown/scss/index.scss
+++ b/src/components/MenuDropdown/scss/index.scss
@@ -13,6 +13,11 @@
     padding: $spacer;
     width: 15rem;
 
+    &__rightdown{
+      right: 0rem!important;
+      left: 1rem!important;
+    }
+    
     &--visible {
       display: block;
       z-index: 2;


### PR DESCRIPTION
I want to merge this change because the account button is invisible on small screens

### Screenshots
<img width="318" alt="Screen Shot 2020-05-08 at 19 53 35" src="https://user-images.githubusercontent.com/24360200/81439017-9e31a700-9165-11ea-89cd-ca1f15cfc7fb.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.